### PR TITLE
Bump zkEVM to v0.0.8 and fix minor typos and formatting

### DIFF
--- a/image-builder.json
+++ b/image-builder.json
@@ -59,7 +59,7 @@
     "image": "pocketfoundation/zkevm-node",
     "context": "polygon-zkevm",
     "dockerfile": "Dockerfile",
-    "tag": "v0.0.7",
+    "tag": "v0.0.8",
     "autobuild": true,
     "watch_repo": "0xPolygonHermez/zkevm-node"
   },

--- a/polygon-zkevm/Dockerfile
+++ b/polygon-zkevm/Dockerfile
@@ -1,8 +1,8 @@
 FROM --platform=linux/amd64 golang:bullseye AS builder
 
 ARG GIT_URL="https://github.com/0xPolygonHermez/zkevm-node.git"
-# AUTO_UPDATE_GIT_COMMIT - next line will be overwritten by build.sh to the latest found releas
-ARG RELEASE="v0.0.7"
+# AUTO_UPDATE_GIT_COMMIT - The following line will be overwritten by build.sh to the latest release found in the GitHub repo in the line above
+ARG RELEASE="v0.0.8"
 
 #build-base linux-headers git bash ca-certificates libstdc++
 RUN apt update && \

--- a/polygon-zkevm/README.md
+++ b/polygon-zkevm/README.md
@@ -1,21 +1,19 @@
-# Main repo
+# Main Repo
 https://github.com/ledgerwatch/erigon
 
-# Description
-This docker container has installed main tools to work with vault, Azure, kubernetes ... and is intended to be used as k8s jobs.
+## Description
+This Docker container has installed main tools to work with vault, Azure, Kubernetes ... and is intended to be used as k8s jobs.
 
-**This image** is used by namespace helm to populate secrets so it **MUST BE PUBLIC**
+**This Image** is used by namespace helm to populate secrets so it **MUST BE PUBLIC**
 
-Entrypoins (or cmd) can be provided with helm (via configmaps).
+Entrypoints (or cmd) can be provided with helm (via configmaps).
 
-
-# Build and Run
+## Build and Run
 
 `docker build --rm -t erigon:latest .`
 
-To run the image
+## To Run the Image
 
 `docker run -it erigon:latest bash`
 
-You can run geth and configs will be in /node folder
-
+You can run Geth and configs will be in the `/node` folder


### PR DESCRIPTION
Bumped zkEVM versions in its Dockerfile, in the image-creator file, and fixed typos and markdown formatting in the zkEVM `README` file